### PR TITLE
bug: Proxy credentials passing

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -315,7 +315,7 @@ module Flexirest
             _, @base_url, @url = parts
           end
           base_url.gsub!(%r{//(.)}, "//#{username}:#{password}@\\1") if username && !base_url[%r{//[^/]*:[^/]*@}]
-          connection = Flexirest::ConnectionManager.get_connection(@base_url)
+          connection = Flexirest::ConnectionManager.get_connection(base_url)
         end
       else
         parts = @url.match(%r{^(https?://[a-z\d\.:-]+?)(/.*)}).to_a

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -147,7 +147,7 @@ describe Flexirest::Connection do
       expect(auth_header == "APIAuth id123:TQiQIW6vVaDC5jvh99uTNkxIg6Q=" || auth_header == "APIAuth id123:PMWBThkB8vKbvUccHvoqu9G3eVk=").to be_truthy
     end
 
-    if Gem.loaded_specs["api-auth"].version.to_s >= "2.0.0"
+    if  Gem.loaded_specs["api-auth"].present? && Gem.loaded_specs["api-auth"].version.to_s >= "2.0.0"
       it 'should have an Authorization header with a custom digest method' do
         puts Gem.loaded_specs["api-auth"].version
         @options[:api_auth][:api_auth_options] = {


### PR DESCRIPTION
Attempt to fix problem with missing HTTP basic auth credentials when making API calls through Proxy. After pulling to my project, problem has gone away. Seems to work fine right now.