### PR TITLE
Fixed has_one association when it's nil.

### DIFF
--- a/lib/flexirest/associations.rb
+++ b/lib/flexirest/associations.rb
@@ -39,6 +39,8 @@ module Flexirest
         @_associations ||= {}
         @_associations[key] = klass
         define_method(key) do
+          return nil if _attributes[key].nil?
+
           if _attributes[key].is_a?(klass)
             return _attributes[key]
           end

--- a/spec/lib/associations_spec.rb
+++ b/spec/lib/associations_spec.rb
@@ -77,6 +77,11 @@ end
 describe "Has One Associations" do
   let(:subject) {AssociationExampleBase.new}
 
+  it "should return nil if it's nil" do
+    subject.child = nil
+    expect(subject.child).to be_nil
+  end
+
   it "should return a list of the association class" do
     subject.child = {test: "foo"}
     expect(subject.child).to be_an(AssociationExampleOther)


### PR DESCRIPTION
I get exception `undefined method each for nil:NilClass` when try to access association which is nil.
This pull request fix it.

Sorry for my English.