### PR TITLE
Fix object instantiation performance issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ would output the following url
 
 ### Automatic Conversion of Fields to Date/DateTime
 
-By default Flexirest will attempt to convert all fields to a Date or DateTime object if it's a string and the value matches a pair of regular expressions. However, on large responses this can be computationally expensive.  So, you can either disable this automatic conversion completely with:
+By default Flexirest will attempt to convert all fields to a Date or DateTime object if it's a string and the value matches a pair of regular expressions. However, on large responses this can be computationally expensive.  You can disable this automatic conversion completely with:
 
 ```ruby
 Flexirest::Base.disable_automatic_date_parsing = true
@@ -715,6 +715,21 @@ class Person < Flexirest::Base
   get :all, '/people', parse_fields: [:created_at, :updated_at]
 end
 ```
+
+It is also possible to whitelist fields should be parsed in your models, which is useful if you are instantiating these objects directly. The specified fields also apply automatically to request mapping.
+
+```ruby
+class Person < Flexirest::Base
+  parse_date :updated_at, :created_at
+end
+
+# to disable all mapping
+class Disabled < Flexirest::Base
+  parse_date :none
+end
+```
+
+This system respects `disable_automatic_date_parsing`, and will default to mapping everything - unless a `parse_date` whitelist is specified, or automatic parsing is globally disabled.
 
 ### Raw Requests
 

--- a/lib/flexirest/associations.rb
+++ b/lib/flexirest/associations.rb
@@ -50,6 +50,19 @@ module Flexirest
           _attributes[key]
         end
       end
+
+      def parse_date(*keys)
+        keys.each { |key| @_date_fields << key }
+      end
+
+      def _date_fields
+        @_date_fields.uniq
+      end
+
+      def inherited(subclass)
+        subclass.instance_variable_set(:@_date_fields, [])
+        super
+      end
     end
 
     def self.included(base)

--- a/lib/flexirest/base.rb
+++ b/lib/flexirest/base.rb
@@ -26,7 +26,7 @@ module Flexirest
 
       attrs.each do |attribute_name, attribute_value|
         attribute_name = attribute_name.to_sym
-        @attributes[attribute_name] = parse_attribute_value(attribute_value)
+        @attributes[attribute_name] = possible_date?(attribute_name) ? parse_attribute_value(attribute_value) : attribute_value
         @dirty_attributes << attribute_name
       end
     end
@@ -173,6 +173,10 @@ module Flexirest
       else
         value.inspect
       end
+    end
+
+    def possible_date?(name)
+      self.class._date_fields.empty? || self.class._date_fields.include?(name)
     end
 
   end

--- a/lib/flexirest/base.rb
+++ b/lib/flexirest/base.rb
@@ -26,7 +26,7 @@ module Flexirest
 
       attrs.each do |attribute_name, attribute_value|
         attribute_name = attribute_name.to_sym
-        @attributes[attribute_name] = possible_date?(attribute_name) ? parse_attribute_value(attribute_value) : attribute_value
+        @attributes[attribute_name] = parse_date?(attribute_name) ? parse_attribute_value(attribute_value) : attribute_value
         @dirty_attributes << attribute_name
       end
     end
@@ -175,8 +175,10 @@ module Flexirest
       end
     end
 
-    def possible_date?(name)
-      self.class._date_fields.empty? || self.class._date_fields.include?(name)
+    def parse_date?(name)
+      return true if self.class._date_fields.include?(name)
+      return true if !Flexirest::Base.disable_automatic_date_parsing && self.class._date_fields.empty?
+      false
     end
 
   end

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -479,9 +479,11 @@ module Flexirest
             end
           end
         else
-          if @method[:options][:parse_fields] && @method[:options][:parse_fields].include?(k)
+          parse_fields = [ @method[:options][:parse_fields], @object._date_fields ].compact.reduce([], :|)
+          parse_fields = nil if parse_fields.empty?
+          if (parse_fields && parse_fields.include?(k))
             object._attributes[k] = parse_attribute_value(v)
-          elsif @method[:options][:parse_fields]
+          elsif parse_fields
             object._attributes[k] = v
           elsif Flexirest::Base.disable_automatic_date_parsing
             object._attributes[k] = v

--- a/spec/lib/associations_spec.rb
+++ b/spec/lib/associations_spec.rb
@@ -29,6 +29,16 @@ class DeepNestedHasManyExample < Flexirest::Base
   get :find, "/iterate", fake: hash.to_json
 end
 
+class WhitelistedDateExample < Flexirest::Base
+  parse_date :updated_at
+end
+
+class WhitelistedDateMultipleExample < Flexirest::Base
+  parse_date :updated_at, :created_at
+  parse_date :generated_at
+end
+
+
 describe "Has Many Associations" do
   let(:subject) {AssociationExampleBase.new}
 
@@ -106,5 +116,31 @@ describe "Has One Associations" do
   it "should return correctly instantiated nested associations" do
     subject.child = {nested_child: {test: "foo"}}
     expect(subject.child.nested_child.test).to eq("foo")
+  end
+end
+
+describe "whitelisted date fields" do
+  context "no whitelist specified" do
+    let(:subject) {AssociationExampleNested}
+
+    it "should show whitelist as empty array" do
+      expect(subject._date_fields).to eq([])
+    end
+  end
+
+  context "whitelist specified" do
+    let(:subject) {WhitelistedDateExample}
+
+    it "should contain whitelisted field" do
+      expect(subject._date_fields).to eq([:updated_at])
+    end
+  end
+
+  context "multiple attributes whitelisted" do
+    let(:subject) {WhitelistedDateMultipleExample}
+
+    it "should contain all fields" do
+      expect(subject._date_fields).to match_array([:updated_at, :created_at, :generated_at])
+    end
   end
 end

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -42,6 +42,11 @@ class InstanceMethodExample < Flexirest::Base
   get :all, "/all"
 end
 
+class WhitelistedDateExample < Flexirest::Base
+  parse_date :updated_at
+end
+
+
 describe Flexirest::Base do
   it 'should instantiate a new descendant' do
     expect{EmptyExample.new}.to_not raise_error
@@ -428,6 +433,24 @@ describe Flexirest::Base do
     it "should set integers as a native JSON type" do
       expect(json_parsed_object["students"].first["age"]).to eq(student1.age)
       expect(json_parsed_object["students"].second["age"]).to eq(student2.age)
+    end
+  end
+
+  describe "instantiating object" do
+    context "no whitelist specified" do
+      it "should convert dates automatically" do
+        client = EmptyExample.new(test: Time.now.iso8601)
+        expect(client["test"]).to be_an_instance_of(DateTime)
+      end
+    end
+
+    context "whitelist specified" do
+      it "should only convert specified dates" do
+        time = Time.now.iso8601
+        client = WhitelistedDateExample.new(updated_at: time, created_at: time)
+        expect(client["updated_at"]).to be_an_instance_of(DateTime)
+        expect(client["created_at"]).to be_an_instance_of(String)
+      end
     end
   end
 

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -99,6 +99,12 @@ describe Flexirest::Request do
       }
     end
 
+    class WhitelistedDateClient < Flexirest::Base
+      base_url "http://www.example.com"
+      put :conversion, "/put/:id"
+      parse_date :converted
+    end
+
     allow_any_instance_of(Flexirest::Request).to receive(:read_cached_response)
   end
 
@@ -283,6 +289,13 @@ describe Flexirest::Request do
   it "should only convert date times in JSON if specified" do
     expect_any_instance_of(Flexirest::Connection).to receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(body:"{\"converted\":\"2012-03-04T01:02:03Z\", \"not_converted\":\"2012-03-04T01:02:03Z\"}", response_headers:{})))
     object = ExampleClient.conversion id:1234, debug:true
+    expect(object.converted).to be_an_instance_of(DateTime)
+    expect(object.not_converted).to be_an_instance_of(String)
+  end
+
+  it "should convert date times in JSON if whitelisted" do
+    expect_any_instance_of(Flexirest::Connection).to receive(:put).with("/put/1234", "debug=true", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(body:"{\"converted\":\"2012-03-04T01:02:03Z\", \"not_converted\":\"2012-03-04T01:02:03Z\"}", response_headers:{})))
+    object = WhitelistedDateClient.conversion id:1234, debug:true
     expect(object.converted).to be_an_instance_of(DateTime)
     expect(object.not_converted).to be_an_instance_of(String)
   end


### PR DESCRIPTION
This PR fixes an issue with slow object instantiation when accessing a deeply nested structure that relies on multiple models (inheriting from `Flexirest::Base`) through `has_many` relations.

The `Flexirest::Base.disable_automatic_date_parsing` option allows date parsing to be disabled when making requests, but it doesn't have any effect when accessing a lazily-loaded child object through a has_many.

The approach taken here is to allow whitelisted properties to be set up on each model - see the changes to README.md for more details.

The changes respect `Flexirest::Base.disable_automatic_date_parsing`: when automatic parsing is enabled (default), not specifying `parse_date` will keep the default behaviour of parsing everything.

Real-world testing of these changes show good improvements - on a particular (admittedly bloated) API request, we've seen the time taken to iterate through the object tree drop from 300ms to under 30ms.

Interested in any thoughts on this approach. Do let me know if anything can be improved!