### PR TITLE
Handle Invalid JSON

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -570,7 +570,12 @@ module Flexirest
       if @response.body.is_a?(Array) || @response.body.is_a?(Hash)
         body = @response.body
       elsif is_json_response?
-        body = @response.body.blank? ? {} : MultiJson.load(@response.body)
+        begin
+          body = @response.body.blank? ? {} : MultiJson.load(@response.body)
+        rescue MultiJson::ParseError => exception
+          raise ResponseParseException.new(status:@response.status, body:@response.body, headers:@response.headers)
+        end
+
         if options[:ignore_root]
           body = body[options[:ignore_root].to_s]
         end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -612,6 +612,23 @@ describe Flexirest::Request do
     expect(e.result).to eq(error_content)
   end
 
+  it "should raise response parse exception for invalid JSON content" do
+    message_content = "Success"
+    expect_any_instance_of(Flexirest::Connection).
+      to receive(:post).
+      with("/create", "first_name=John&should_disappear=true", an_instance_of(Hash)).
+      and_return(::FaradayResponseMock.new(OpenStruct.new(body:message_content, response_headers:{'Content-Type' => 'application/json'}, status:200)))
+    object = ExampleClient.new(first_name:"John", should_disappear:true)
+    begin
+      object.create
+    rescue => e
+      e
+    end
+    expect(e).to be_instance_of(Flexirest::ResponseParseException)
+    expect(e.status).to eq(200)
+    expect(e.body).to eq(message_content)
+  end
+
   it "should raise response parse exception for 200 response status and non json content type" do
     error_content = "<h1>malformed json</h1>"
     expect_any_instance_of(Flexirest::Connection).


### PR DESCRIPTION
Handle responses which have `content-type: application/json` but do not actually contain properly formatted JSON bodies