### PR TITLE
 Better Empty Response Handling

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -403,7 +403,7 @@ module Flexirest
         if @method[:options][:plain]
           return @response = Flexirest::PlainResponse.from_response(response)
         elsif status == 204 && @response.body.blank?
-          return true
+          return {}
         elsif is_json_response? || is_xml_response?
           if @response.respond_to?(:proxied) && @response.proxied
             Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Response was proxied, unable to determine size"

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -327,7 +327,7 @@ describe Flexirest::Request do
 
   it "should return true from 204 with empty bodies" do
     expect_any_instance_of(Flexirest::Connection).to receive(:get).with(any_args).and_return(::FaradayResponseMock.new(OpenStruct.new(status:204, response_headers:{}, body: nil)))
-    expect(ExampleClient.all).to be_truthy
+    expect(ExampleClient.all).to eq({})
   end
 
   it "should return a lazy loader object if lazy loading is enabled" do


### PR DESCRIPTION
Having an empty response from an api result in TrueClass breaks many implementations as systems expect to be able to check for presence of attributes without having an exception be raised.
