### PR TITLE
Fix to be possible to disable caching for each objects

### DIFF
--- a/lib/flexirest/caching.rb
+++ b/lib/flexirest/caching.rb
@@ -4,7 +4,7 @@ module Flexirest
       @@perform_caching = true
 
       def perform_caching(value = nil)
-        @perform_caching ||= nil
+        @perform_caching = nil unless instance_variable_defined?(:@perform_caching)
         if value.nil?
           value = if @perform_caching.nil?
             @@perform_caching

--- a/spec/lib/caching_spec.rb
+++ b/spec/lib/caching_spec.rb
@@ -35,6 +35,20 @@ describe Flexirest::Caching do
       Flexirest::Base._reset_caching!
     end
 
+    it "should be possible to disable caching for each objects" do
+      Flexirest::Base.perform_caching = true
+
+      class CachingExample4 < Flexirest::Base; end
+      class CachingExample5 < Flexirest::Base
+        perform_caching false
+      end
+      expect(Flexirest::Base.perform_caching).to be_truthy
+      expect(CachingExample4.perform_caching).to be_truthy
+      expect(CachingExample5.perform_caching).to be_falsey
+
+      Flexirest::Base._reset_caching!
+    end
+
     it "should use Rails.cache if available" do
       begin
         class Rails


### PR DESCRIPTION
### Example classes
``` ruby
class Example1 < Flexirest::Base; end
class Example2 < Flexirest::Base
  perform_caching false
end
```

### Expected behavior
``` ruby
irb(main):001:0> Flexirest::Base.perform_caching
=> true
irb(main):002:0> Example1.perform_caching
=> true
irb(main):003:0> Example2.perform_caching
=> false
```

### Actual behavior(v1.3.33)
``` ruby
irb(main):001:0> Flexirest::Base.perform_caching
=> true
irb(main):002:0> Example1.perform_caching
=> true
irb(main):003:0> Example2.perform_caching
=> true
```