### PR TITLE
Fix rspec failure when using webmock v2.2.0 or above

### DIFF
--- a/flexirest.gemspec
+++ b/flexirest.gemspec
@@ -22,7 +22,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3"
-  spec.add_development_dependency "webmock"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
+    spec.add_development_dependency "webmock", "~> 2.1.0"
+  else
+    spec.add_development_dependency "webmock"
+  end
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-rcov"

--- a/lib/flexirest/connection.rb
+++ b/lib/flexirest/connection.rb
@@ -26,11 +26,17 @@ module Flexirest
       block.call
     rescue Faraday::Error::TimeoutError
       raise Flexirest::TimeoutException.new("Timed out getting #{full_url(path)}")
-    rescue Faraday::Error::ConnectionFailed
+    rescue Faraday::Error::ConnectionFailed => e1
+      if e1.respond_to?(:cause) && e1.cause.is_a?(Net::OpenTimeout)
+        raise Flexirest::TimeoutException.new("Timed out getting #{full_url(path)}")
+      end
       begin
         reconnect
         block.call
-      rescue Faraday::Error::ConnectionFailed
+      rescue Faraday::Error::ConnectionFailed => e2
+        if e2.respond_to?(:cause) && e2.cause.is_a?(Net::OpenTimeout)
+          raise Flexirest::TimeoutException.new("Timed out getting #{full_url(path)}")
+        end
         raise Flexirest::ConnectionFailedException.new("Unable to connect to #{full_url(path)}")
       end
     end


### PR DESCRIPTION
This is a ~~temporary~~ fix to make rspec work well.

Webmock is now raising `Net::OpenTimeout` in `to_timeout` since v2.2.0.
However, faraday is raising `Faraday::Error::ConnectionFailed` when it rescued `Net::OpenTimeout` on v0.11.0

* https://github.com/bblimke/webmock/blob/v2.3.2/CHANGELOG.md#220
* https://github.com/lostisland/faraday/blob/v0.11.0/lib/faraday/adapter/net_http.rb#L29-L57