### PR TITLE
Adds Mongoid/AR style dirty tracking and :only_changed method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If you are a previous user of ActiveRestClient, there's some more information on
 	- [Default Parameters](#default-parameters)
 	- [Root element removal](#root-element-removal)
 	- [Required Parameters](#required-parameters)
+	- [Updating Only Changed/Dirty](#updating-only-changed-dirty)
 	- [HTTP/Parse Error Handling](#httpparse-error-handling)
 	- [Validation](#validation)
 		- [Permitting nil values](#permitting-nil-values)
@@ -936,6 +937,38 @@ end
 @people = Person.all # raises Flexirest::MissingParametersException
 @people = Person.all(active:false)
 ```
+
+### Updating Only Changed/Dirty
+
+The most common RESTful usage of the PATCH http-method is to only send fields that have changed. The default action for all calls is to send all known object attributes for POST/PUT/PATCH calls, but this can be altered by setting the `only_changed` option on your call declaration.
+
+```ruby
+class Person < Flexirest::Base
+  get :all, '/people'
+  patch :update, '/people/:id', :only_changed => true # only send attributes that are changed/dirty
+end
+
+person = Person.all.first
+person.first_name = 'Billy'
+person.update # performs a PATCH request, sending only the now changed 'first_name' attribute
+```
+
+This functionality is per-call, and there is some additional flexibility to control which attributes are sent and when.
+
+```ruby
+class Person < Flexirest::Base
+  get :all, '/people'
+  patch :update_1, '/people/:id', :only_changed => true # only send attributes that are changed/dirty (all known attributes on this object are subject to evaluation)
+  patch :update_2, "/people/:id", :only_changed => [:first_name, :last_name, :dob] # only send these listed attributes, and only if they are changed/dirty
+  patch :update_3, "/people/:id", :only_changed => {first_name: true, last_name: true, dob: false} # include the listed attributes marked 'true' only when changed; attributes marked 'false' are always included (changed or not, and if not present will be sent as nil); unspecified attributes are never sent
+end
+```
+
+#### Additional Notes:
+
+* The above examples specifically showed PATCH methods, but this is also available for POST and PUT methods for flexibility purposes (even though they break typical REST methodology).
+* This logic is currently evaluated before Required Parameters, so it is possible to ensure that requirements are met by some clever usage.
+ - Ie, if a method is `:requires => [:active], :only_changed => {active: false}` then `active` will always have a value and would always pass the `:requires` directive (so you need to be very careful because the answer may end up being `nil` if you didn't specifically set it).
 
 ### HTTP/Parse Error Handling
 

--- a/lib/flexirest/version.rb
+++ b/lib/flexirest/version.rb
@@ -1,3 +1,3 @@
 module Flexirest
-  VERSION = "1.3.33"
+  VERSION = "1.3.34"
 end


### PR DESCRIPTION


* Changed Flexirest::Base.@dirty_attributes type from Set to Hash and added storage of previous values upon change
* Added ActiveRecord/Mongoid style dirty/changed tracking methods and associated tests
* Increased base instance_methods.size test from 10 to 13 to accommodate new public methods
* Added 2nd chance to ensure URL path variables resolve against object attributes, even if they aren’t part of the specific request data
* Bumped version to 1.3.34 (just to have something different for the pull request)