### PR TITLE
Require the user to provide URI.encoded parameters

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -307,7 +307,7 @@ module Flexirest
           target = @get_params.delete(token.to_sym) || @post_params.delete(token.to_sym) || @get_params.delete(token.to_s) || @post_params.delete(token.to_s) || ""
           # it's possible the URL path variable may not be part of the request, in that case, try to resolve it from the object attributes
           target = @object._attributes[token.to_sym] || "" if target == ""
-          @url.gsub!(":#{token}", URI.escape(target.to_s))
+          @url.gsub!(":#{token}", target.to_s)
         end
       end
     end


### PR DESCRIPTION
Remove the URI.encoding done in the prepare_url method of the URL. Due to an issue where the parameter has a '/' in the name which will not be encoded byt URI.encoding and resulting in an invalid URL path. If the parameters are encoded before sending to FlexiRest, the perpare_url method encodes the URL path which results in a double encoding of the now encoded '/' '%2F' into '%252F' which is an invalid URL as well. 

This fixes #73, by removing the URI.encoding in the prepare_url method and requiring the user to provide a URL encoded parameters.

This could be enhanced with a option to encode or not on a global, model, or individual request.
