### PR TITLE
replace '+' with '%2B' to be able to search ID strings containing '+'

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -307,7 +307,7 @@ module Flexirest
           target = @get_params.delete(token.to_sym) || @post_params.delete(token.to_sym) || @get_params.delete(token.to_s) || @post_params.delete(token.to_s) || ""
           # it's possible the URL path variable may not be part of the request, in that case, try to resolve it from the object attributes
           target = @object._attributes[token.to_sym] || "" if target == ""
-          @url.gsub!(":#{token}", URI.escape(target.to_s).gsub("/", "%2F"))
+          @url.gsub!(":#{token}", URI.escape(target.to_s).gsub("/", "%2F").gsub("+", "%2B"))
         end
       end
     end


### PR DESCRIPTION
I escaped the '+' char in the search URL params. I need to search strings containing '+' (e.g. 'ID+1234') char and I was not able to escape the string any other way. It always searched the exact string I have provided except for '+' which was substituted by a space.

This is the only solution I have found. It would be nice to have it in master if there is no other implemented way how to search '+'.