### PR TITLE
JSON API: Instantiate class if mapped request method is called

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -337,7 +337,10 @@ module Flexirest
           @body = ""
         else
           headers["Content-Type"] ||= "application/vnd.api+json"
-          @body = JsonAPIProxy::Request::Params.create(params || @post_params || {}, @object).to_json
+          @body = JsonAPIProxy::Request::Params.create(
+            params || @post_params || {},
+            object_is_class? ? @object.new : @object
+          ).to_json
         end
 
         headers["Accept"] ||= "application/vnd.api+json"


### PR DESCRIPTION
I added a test for a scenario in which a user sends a request to the JSON API service without initializing a record. That is, a user should be able to call `Article.create` and `Article.create(params)`.

My apologies for not having included this functionality in my previous PR. Thanks to a friend of mine who has started using the JSON API proxy. He reported to me this missing feature today.