### PR TITLE
WIP: Allow validation of associated models using `validates_associated`.

### DIFF
--- a/lib/flexirest/validation.rb
+++ b/lib/flexirest/validation.rb
@@ -3,7 +3,14 @@ module Flexirest
     module ClassMethods
       def validates(field_name, options={}, &block)
         @_validations ||= []
-        @_validations << {field_name:field_name, options:options, block:block}
+        @_validations << { field_name: field_name, options: options, block: block }
+      end
+
+      def validates_associated(field_name, options={}, &block)
+        _associations[field_name]._validations.each do |validation|
+          @_validations ||= []
+          @_validations << validation
+        end
       end
 
       def _validations

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -280,6 +280,32 @@ describe "Flexirest::Validation" do
     end
   end
 
+  context "when validating associated models" do
+    class ChildExample < Flexirest::Base
+      validates :first_name, presence: true
+    end
+    
+    class AssociatedValidationExample < Flexirest::Base
+      include Flexirest::Validation
+      has_one :child, ChildExample
+      validates_associated :child
+    end
+
+    it "should be invalid when the associated model is invalid" do
+      child = ChildExample.new
+      child.valid?
+      expect(child._errors[:first_name].size).to eq(1)
+
+      a = AssociatedValidationExample.new(child: child)
+      a.valid?
+      expect(a.valid?).to be false
+      expect(a._errors[:first_name].size).to eq(1)
+    end
+
+    it "should be valid when the associated model is valid" do
+    end
+  end
+
   describe "#full_error_messages" do
     it "should return an array of strings that combines the attribute name and the error message" do
       a = SimpleValidationExample.new(age:"Bob", suffix: "Baz")


### PR DESCRIPTION
Hey @andyjeffries – this is a work in progress, but I thought I'd raise an early pull request to see what you think. There's a problem at the moment where it just adds an error to the original `field_name`, instead of associating it somehow with the child record. I also need to consider how this works for non-`has_one` associations, too.

I'll update here when I make more progress, but welcome any early feedback.