### PR TITLE
Use Faraday's conn.basic_auth method for HTTP basic authentication

### DIFF
--- a/lib/flexirest/configuration.rb
+++ b/lib/flexirest/configuration.rb
@@ -63,18 +63,12 @@ module Flexirest
             value
           end
         else
-          if value.respond_to?(:call)
-            @username = value
-          else
-            value = CGI::escape(value) if value.present? && !value.include?("%")
-            @username = value
-          end
+          @username = value
         end
       end
 
       def username=(value)
         Flexirest::Logger.info "\033[1;4;32m#{name}\033[0m Username set to be #{value}"
-        value = CGI::escape(value) if value.present? && !value.include?("%")
         @@username = value
       end
 
@@ -94,18 +88,12 @@ module Flexirest
             value
           end
         else
-          if value.respond_to?(:call)
-            @password = value
-          else
-            value = CGI::escape(value) if value.present? && !value.include?("%")
-            @password = value
-          end
+          @password = value
         end
       end
 
       def password=(value)
         Flexirest::Logger.info "\033[1;4;32m#{name}\033[0m Password set..."
-        value = CGI::escape(value) if value.present? && !value.include?("%")
         @@password = value
       end
 

--- a/lib/flexirest/connection.rb
+++ b/lib/flexirest/connection.rb
@@ -22,6 +22,10 @@ module Flexirest
       @session.headers
     end
 
+    def basic_auth(username, password)
+      @session.basic_auth(username, password)
+    end
+
     def make_safe_request(path, &block)
       block.call
     rescue Faraday::Error::TimeoutError

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -446,7 +446,6 @@ module Flexirest
           else
             _, @base_url, @url = parts
           end
-          base_url.gsub!(%r{//(.)}, "//#{username}:#{password}@\\1") if username && !base_url[%r{//[^/]*:[^/]*@}]
           connection = Flexirest::ConnectionManager.get_connection(base_url)
         end
       else
@@ -459,13 +458,16 @@ module Flexirest
         else
           base_url = parts[0]
         end
-        base_url.gsub!(%r{//(.)}, "//#{username}:#{password}@\\1") if username && !base_url[%r{//[^/]*:[^/]*@}]
         connection = Flexirest::ConnectionManager.get_connection(base_url)
       end
       if @method[:options][:direct]
         Flexirest::Logger.info "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Requesting #{@url}"
       else
         Flexirest::Logger.info "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Requesting #{connection.base_url}#{@url}"
+      end
+
+      if username
+        connection.basic_auth(username, password)
       end
 
       if verbose?

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -81,18 +81,6 @@ describe Flexirest::Configuration do
     expect(SubConfigurationExample.username).to eq("john")
   end
 
-  it "should escape the username" do
-    Flexirest::Base.username = "bill@example.com"
-    expect(Flexirest::Base.username).to eq("bill%40example.com")
-    Flexirest::Base.username = nil
-  end
-
-  it "should not doubly escape the username" do
-    Flexirest::Base.username = "bill%40example.com"
-    expect(Flexirest::Base.username).to_not eq("bill%2540example.com")
-    Flexirest::Base.username = nil
-  end
-
   it "should remember the set password" do
     expect(ConfigurationExample.password).to eq("smith")
   end
@@ -105,18 +93,6 @@ describe Flexirest::Configuration do
 
   it "should remember the set password on a class, overriding a general one" do
     expect(SubConfigurationExample.password).to eq("smith")
-  end
-
-  it "should escape the password" do
-    Flexirest::Base.password = "something@else"
-    expect(Flexirest::Base.password).to eq("something%40else")
-    Flexirest::Base.password = nil
-  end
-
-  it "should not doubly escape the password" do
-    Flexirest::Base.password = "something%40else"
-    expect(Flexirest::Base.password).to_not eq("something%2540else")
-    Flexirest::Base.password = nil
   end
 
   it "should default to a form_encoded request_body_type" do


### PR DESCRIPTION
Hi @andyjeffries – I had a problem with some HTTP Basic Authentication, where the handling of usernames containing an `@` symbol was causing Flexirest to fail in two ways.

Firstly, an invalid string was being generated and passed to `URI.parse`. For some reason, in my Rails application, the stack trace was being swallowed, but I suspect this was happening in the `do_request` method when the `@base_url` was being parsed. Here's an example:

```
URI.parse("https://sam@google.com:foo@example.org")
URI::InvalidURIError: bad URI(is not URI?): https://sam@google.com:foo@example.org
	from /Users/samstarling/.rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/rfc3986_parser.rb:67:in `split'
	from /Users/samstarling/.rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/rfc3986_parser.rb:73:in `parse'
	from /Users/samstarling/.rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/common.rb:227:in `parse'
	from (irb):2
	from /Users/samstarling/.rbenv/versions/2.3.1/bin/irb:11:in `<main>'
```

Secondly, because of this escaping, authentication was failing. I think this is because the `Authorization` header is incorrect after escaping the field:

```
conn.basic_auth('sam@google.com', 'password')
> Basic c2FtQGdvb2dsZS5jb206cGFzc3dvcmQ=

conn.basic_auth(CGI::escape('sam@google.com'), 'password')
> Basic c2FtJTQwZ29vZ2xlLmNvbTpwYXNzd29yZA==
```

For the API I am using, the first header is valid, but the second is not. Currently, Flexirest produces the second one – so I can't use it for any username that includes an `@`. This PR moves to using the `conn.basic_auth` method, which I believe removes the need to escape the usernames and passwords.

Please let me know if this is a terrible idea, or if I missed something!