### PR TITLE
 Fix fetching included nested associations in json:api proxy 

### DIFF
--- a/lib/flexirest/associations.rb
+++ b/lib/flexirest/associations.rb
@@ -44,7 +44,7 @@ module Flexirest
           if _attributes[key].is_a?(klass)
             return _attributes[key]
           end
-          
+
           _attributes[key] = klass.new(_attributes[key])
 
           _attributes[key]

--- a/lib/flexirest/associations.rb
+++ b/lib/flexirest/associations.rb
@@ -44,7 +44,6 @@ module Flexirest
           if _attributes[key].is_a?(klass)
             return _attributes[key]
           end
-
           _attributes[key] = klass.new(_attributes[key])
 
           _attributes[key]

--- a/lib/flexirest/associations.rb
+++ b/lib/flexirest/associations.rb
@@ -44,6 +44,7 @@ module Flexirest
           if _attributes[key].is_a?(klass)
             return _attributes[key]
           end
+          
           _attributes[key] = klass.new(_attributes[key])
 
           _attributes[key]

--- a/spec/lib/json_api_spec.rb
+++ b/spec/lib/json_api_spec.rb
@@ -84,6 +84,24 @@ class JsonAPIExampleArticle < Flexirest::Base
       relationships: { 'tags' => { data: [] }, 'author' => { data: nil } }
     }
   }
+  faker7 = {
+    data: {
+      id: 1, type: 'articles', attributes: { item: 'item one' },
+      relationships: {
+        'tags' => { data: [{ id: 1, type: 'tags' }, { id: 2, type: 'tags' }] },
+        'superman' => {
+          links: {
+            self: 'http://www.example.com/articles/1/relationships/superman',
+            related: 'http://www.example.com/articles/1/superman'
+          }
+        }
+      }
+    },
+    included: [
+      { id: 1, type: 'tags', attributes: { item: 'item two' } },
+      { id: 2, type: 'tags', attributes: { item: 'item three' } }
+    ]
+  }
 
   get(
     :find,
@@ -124,6 +142,13 @@ class JsonAPIExampleArticle < Flexirest::Base
     :no_assocs,
     '/articles/:id',
     fake: faker6.to_json,
+    fake_content_type: 'application/vnd.api+json'
+  )
+
+  get(
+    :not_recognized_assoc,
+    '/articles/:id',
+    fake: faker7.to_json,
     fake_content_type: 'application/vnd.api+json'
   )
 end
@@ -313,6 +338,10 @@ describe 'JSON API' do
       expect(article.find_lazy(1).tags.first.id).to_not be_nil
       expect(article.find_lazy(1).author).to be_an_instance_of(JsonAPIExample::Author)
       expect(article.find_lazy(1).author.id).to_not be_nil
+    end
+
+    it 'should raise exception when an association in the response is not defined in base class' do
+      expect(-> { subject.includes(:tags).not_recognized_assoc(1) }).to raise_error(Exception)
     end
   end
 


### PR DESCRIPTION
I experienced some problems with fetching nested associations from the compound document (= included key from a response). They were regularly not included in the response. I fixed this issue, and I also added the  or  parameters to the parsed response object which are filled with the IDs of the associated resources. Furthermore, I add LazyAssociationsLoaders in case a record cannot be found in the compound document, instead of the resource yielding nil whereas the associated ID may be non-nil.