### PR TITLE
Handle "null" json responses

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -721,14 +721,11 @@ module Flexirest
       elsif is_json_response?
         begin
           body = @response.body.blank? ? {} : MultiJson.load(@response.body)
+          body = {} if body.nil?
         rescue MultiJson::ParseError
           raise ResponseParseException.new(status:@response.status, body:@response.body, headers:@response.headers)
         end
         
-        if body.nil?
-          return nil
-        end
-
         if is_json_api_response?
           body = JsonAPIProxy::Response.parse(body, @object)
         end

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -724,6 +724,10 @@ module Flexirest
         rescue MultiJson::ParseError
           raise ResponseParseException.new(status:@response.status, body:@response.body, headers:@response.headers)
         end
+        
+        if body.nil?
+          return nil
+        end
 
         if is_json_api_response?
           body = JsonAPIProxy::Response.parse(body, @object)

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -725,7 +725,7 @@ module Flexirest
         rescue MultiJson::ParseError
           raise ResponseParseException.new(status:@response.status, body:@response.body, headers:@response.headers)
         end
-        
+
         if is_json_api_response?
           body = JsonAPIProxy::Response.parse(body, @object)
         end


### PR DESCRIPTION
"null" gets parsed to nil and causes the following code to break.

With this patch nil gets returned.