### PR TITLE
Parse errors if JSONAPI responds with an error document

### DIFF
--- a/lib/flexirest/json_api_proxy.rb
+++ b/lib/flexirest/json_api_proxy.rb
@@ -198,7 +198,7 @@ module Flexirest
 
         # Retrieve the resource(s) object or array from the data object
         records = body['data']
-        return records unless records.present?
+        return body['errors'] unless records.present?
 
         # Convert the resource object to an array,
         # because it is easier to work with an array than a single object


### PR DESCRIPTION
Instead of receiving a Flexirest error when a JSONAPI response has `errors` as a key instead of `data`, we get an NPE because the body is nil. This responds with the `errors` array, and thus gives us the ability to rescue from a `Flexirest::HTTPBadRequestClientException` instead of the less obvious `NoMethodError`.