### PR TITLE
Update usage of Faraday error classes

### DIFF
--- a/lib/flexirest/connection.rb
+++ b/lib/flexirest/connection.rb
@@ -24,7 +24,7 @@ module Flexirest
 
     def make_safe_request(path, &block)
       block.call
-    rescue Faraday::Error::TimeoutError
+    rescue Faraday::TimeoutError
       raise Flexirest::TimeoutException.new("Timed out getting #{full_url(path)}")
     rescue Faraday::ConnectionFailed => e1
       if e1.respond_to?(:cause) && e1.cause.is_a?(Net::OpenTimeout)

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -186,7 +186,7 @@ describe Flexirest::Connection do
   end
 
   it "should retry once in the event of a connection failed" do
-    stub_request(:get, "www.example.com/foo").to_raise(Faraday::Error::ConnectionFailed.new("Foo"))
+    stub_request(:get, "www.example.com/foo").to_raise(Faraday::ConnectionFailed.new("Foo"))
     expect { @connection.get("/foo") }.to raise_error(Flexirest::BaseException)
   end
 


### PR DESCRIPTION
Faraday 1.0.0 got out and updated the hierarchy of its error classes:
https://github.com/lostisland/faraday/blob/ff9dc1d1219a1bbdba95a9a4cf5d135b97247ee2/UPGRADING.md

We must now use `Faraday::TimeoutError` instead of `Faraday::Error::TimeoutError`.

It is worth noting that using `Faraday::TimeoutError` works with the older 0.17.3 version of Faraday, so this change will not impact projects that do not wish to upgrade to Faraday 1.0 (I successfully ran rspec locally with both Faraday versions).