### PR TITLE
Add support for JSON API relationships with a custom name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea/

--- a/lib/flexirest/connection.rb
+++ b/lib/flexirest/connection.rb
@@ -24,7 +24,7 @@ module Flexirest
 
     def make_safe_request(path, &block)
       block.call
-    rescue Faraday::Error::TimeoutError
+    rescue Faraday::TimeoutError
       raise Flexirest::TimeoutException.new("Timed out getting #{full_url(path)}")
     rescue Faraday::ConnectionFailed => e1
       if e1.respond_to?(:cause) && e1.cause.is_a?(Net::OpenTimeout)

--- a/lib/flexirest/json_api_proxy.rb
+++ b/lib/flexirest/json_api_proxy.rb
@@ -292,12 +292,14 @@ module Flexirest
 
         # Retrieve the linked resource id and its pluralized type name
         rel_id = relationships[name]['data']['id']
-        plural_name = name.pluralize
+
+        type_name = relationships[name]['data']['type']
+        plural_type_name = type_name.pluralize
 
         # Traverse through the included object, and find the included
         # linked resource, based on the given id and pluralized type name
         linked_resource = included.select do |i|
-          i['id'] == rel_id && i['type'] == plural_name
+          i['id'] == rel_id && i['type'] == plural_type_name
         end
 
         return linked_resource, rel_id, true
@@ -313,12 +315,15 @@ module Flexirest
 
         # Retrieve the linked resources ids
         rel_ids = relationships[name]['data'].map { |r| r['id'] }
-        plural_name = name.pluralize
+
+        # Index the linked resources' id and types that we need to
+        # retrieve from the included resources
+        relations_to_include = relationships[name]['data'].map { |r| [r['id'], r['type']] }.to_set
 
         # Traverse through the included object, and find the included
         # linked resources, based on the given ids and type name
         linked_resources = included.select do |i|
-          rel_ids.include?(i['id']) && i['type'] == plural_name
+          relations_to_include.include?([i['id'], i['type']])
         end
 
         return linked_resources, rel_ids, true

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -186,7 +186,7 @@ describe Flexirest::Connection do
   end
 
   it "should retry once in the event of a connection failed" do
-    stub_request(:get, "www.example.com/foo").to_raise(Faraday::Error::ConnectionFailed.new("Foo"))
+    stub_request(:get, "www.example.com/foo").to_raise(Faraday::ConnectionFailed.new("Foo"))
     expect { @connection.get("/foo") }.to raise_error(Flexirest::BaseException)
   end
 

--- a/spec/lib/json_api_spec.rb
+++ b/spec/lib/json_api_spec.rb
@@ -74,7 +74,7 @@ class JsonAPIExampleArticle < Flexirest::Base
     },
     included: [
       { id: 1, type: 'tags', attributes: { item: 'item three' },
-        relationships: { 'authors' => { data: [{ id: 1, type: 'tags' }] } } },
+        relationships: { 'authors' => { data: [{ id: 1, type: 'authors' }] } } },
       { id: 1, type: 'authors', attributes: { item: 'item two' } }
     ]
   }


### PR DESCRIPTION
By "custom" I mean, that have a different name than the type name.

We should not use the relationship's name (pluralized) to extract the included resources, but rather lookup the relationship's type.

Example: an article can have an "author" relationship that points to an included resource of type "users".