### PR TITLE
Fix crash on JSONAPI error repsonse

### DIFF
--- a/lib/flexirest/json_api_proxy.rb
+++ b/lib/flexirest/json_api_proxy.rb
@@ -198,7 +198,7 @@ module Flexirest
 
         # Retrieve the resource(s) object or array from the data object
         records = body['data']
-        return records unless records.present?
+        return body['errors'] unless records.present?
 
         # Convert the resource object to an array,
         # because it is easier to work with an array than a single object


### PR DESCRIPTION
*Note this PR is an imporvement over https://github.com/flexirest/flexirest/pull/107 which is incomplete. I tried to complete it through https://github.com/shekibobo/flexirest/pull/1 but @shekibobo was unresponsive.*

This PR prevents a crash in JSONAPI mode. The crash happens when the response is an error, this having an `"errors"` key but no `"data"` key.

Behaviour before this PR:
Confusing error is raised: `NoMethodError: undefined method `each' for nil:NilClass`

Behaviour after this PR:
The appropriate Flexirest exception (for example `Flexirest::HTTPNotFoundClientException`) is raised, allowing the error to be rescued properly.