### PR TITLE
Prevent crash when JSONAPI response["data"] is an empty array

### DIFF
--- a/lib/flexirest/json_api_proxy.rb
+++ b/lib/flexirest/json_api_proxy.rb
@@ -196,9 +196,14 @@ module Flexirest
         # Save resource class for building lazy association loaders
         save_resource_class(object)
 
+        # try to return errors if their is no data
+        return body.fetch("errors", {}) if body['data'].nil?
+
+        # return early if data is an empty array
+        return [] if body['data'] == []
+
         # Retrieve the resource(s) object or array from the data object
         records = body['data']
-        return body['errors'] unless records.present?
 
         # Convert the resource object to an array,
         # because it is easier to work with an array than a single object

--- a/spec/lib/json_api_spec.rb
+++ b/spec/lib/json_api_spec.rb
@@ -239,6 +239,7 @@ module JsonAPIExample
       }
     }
 
+    get(:real_index, '/articles')
     get(:real_find, '/articles/:id')
 
     get(
@@ -311,24 +312,42 @@ describe 'JSON API' do
       expect(subject.find_all).to be_an_instance_of(Flexirest::ResultIterator)
     end
 
-    it 'should raise an error when response has "errors" key and no "data"' do
-      body = {
-        errors: [
-          {
-            title: "Record not found",
-            detail: "The record identified by 123456 could not be found",
-            code: "not_found",
-            status: "404",
-          }
-        ]
-      }
-      headers = { "Content-Type" => "application/vnd.api+json" }
-      expect_any_instance_of(Flexirest::Connection).
-        to receive(:get).with("/articles/123", an_instance_of(Hash)).
-        and_return(::FaradayResponseMock.new(OpenStruct.new(body: body.to_json, response_headers: headers, status: 404)))
+    context 'when response has "errors" key and no "data" key' do
+      let(:headers) { { "Content-Type" => "application/vnd.api+json" } }
+      let(:response_body) do
+        {
+          errors: [
+            {
+              title: "Record not found",
+              detail: "The record identified by 123456 could not be found",
+              code: "not_found",
+              status: "404",
+            }
+          ]
+        }
+      end
 
-      expect(-> { JsonAPIExample::Article.real_find(123) }).to raise_error(Flexirest::HTTPNotFoundClientException) do |exception|
-        expect(exception.result.first.title).to eq("Record not found")
+      it 'should raise a Flexirest error' do
+        expect_any_instance_of(Flexirest::Connection).
+          to receive(:get).with("/articles/123", an_instance_of(Hash)).
+          and_return(::FaradayResponseMock.new(OpenStruct.new(body: response_body.to_json, response_headers: headers, status: 404)))
+
+        expect(-> { JsonAPIExample::Article.real_find(123) }).to raise_error(Flexirest::HTTPNotFoundClientException) do |exception|
+          expect(exception.result.first.title).to eq("Record not found")
+        end
+      end
+    end
+
+    context 'when response has an empty "data" key' do
+      let(:headers) { { "Content-Type" => "application/vnd.api+json" } }
+      let(:response_body) { { data: [] } }
+
+      it 'should return an empty array' do
+        expect_any_instance_of(Flexirest::Connection).
+          to receive(:get).with("/articles", an_instance_of(Hash)).
+          and_return(::FaradayResponseMock.new(OpenStruct.new(body: response_body.to_json, response_headers: headers, status: 200)))
+
+        expect(JsonAPIExample::Article.real_index.to_a).to eq([])
       end
     end
   end


### PR DESCRIPTION
**Important: it was introduced in `1.9.10` and impacts a lot of usages (that is, any JSONAPI response that returns an empty array as `"data"`)**

This was my bad, I did not test this very common case in #121.