### PR TITLE
Prevent crash on JSONAPI invalid error response

### DIFF
--- a/lib/flexirest/json_api_proxy.rb
+++ b/lib/flexirest/json_api_proxy.rb
@@ -196,8 +196,10 @@ module Flexirest
         # Save resource class for building lazy association loaders
         save_resource_class(object)
 
-        # try to return errors if their is no data
-        return body.fetch("errors", {}) if body['data'].nil?
+        # According to the spec:
+        # "The members data and errors MUST NOT coexist in the same document."
+        # Thus, if the "errors" key is present, we can return it and ignore the "data" key.
+        return body['errors'] if body.include?('errors')
 
         # return early if data is an empty array
         return [] if body['data'] == []


### PR DESCRIPTION
Prevent crash on JSONAPI invalid error response

According to the spec:

    The members data and errors MUST NOT coexist in the same document.

(https://jsonapi.org/format/#document-top-level)

However sometimes a server will produce an error response which include both
a (legit) `"errors"` and an (invalid) `"data"` key, which so far
caused Flexirest to crash instead of raising the proper Flexirest exception.

This fix prevents the crash and makes Flexirest raise the relevant exception.