### PR TITLE
Cache control feature

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,12 +1,12 @@
 # *Flexirest:* Caching
 
-Expires and ETag based caching is enabled by default, but with a simple line in the application.rb/production.rb you can disable it:
+Cache-Control, Expires and ETag based caching are enabled by default, but with a simple line in the application.rb/production.rb you can disable it:
 
 ```ruby
 Flexirest::Base.perform_caching = false
 ```
 
-or you can disable it per classes with:
+or you can also disable it per classes with:
 
 ```ruby
 class Person < Flexirest::Base

--- a/flexirest.gemspec
+++ b/flexirest.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "crack"
   spec.add_runtime_dependency "faraday"
+  spec.add_runtime_dependency "rack-cache"
 
   # Use Gem::Version to parse the Ruby version for reliable comparison
   # ActiveSupport 5+ requires Ruby 2.2.2

--- a/spec/lib/caching_spec.rb
+++ b/spec/lib/caching_spec.rb
@@ -124,15 +124,16 @@ describe Flexirest::Caching do
 
       Person.cache_store = CachingExampleCacheStore5.new
 
+      @cache_control = "public, max-age=30"
       @etag = "6527914a91e0c5769f6de281f25bd891"
       @cached_object = Person.new(first_name:"Johnny")
     end
 
     it "should read from the cache store, to check for an etag" do
-      cached_response = Flexirest::CachedResponse.new(
-        status:200,
-        result:@cached_object,
-        etag:@etag)
+      headers = {
+        Rack::ETAG => @etag
+      }
+      cached_response = Rack::Cache::Response.new(200, headers, @cached_object.to_json)
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
       expect_any_instance_of(Flexirest::Connection).to receive(:get){ |connection, path, options|
         expect(path).to eq('/')
@@ -143,21 +144,21 @@ describe Flexirest::Caching do
     end
 
     it "should not read from the cache store to check for an etag unless it's a GET request" do
-      cached_response = Flexirest::CachedResponse.new(
-        status:200,
-        result:@cached_object,
-        etag:@etag)
+      headers = {
+        Rack::ETAG => @etag,
+        Rack::EXPIRES => (Time.now + 30).httpdate
+      }
+      cached_response = Rack::Cache::Response.new(200, headers, @cached_object.to_json)
       expect_any_instance_of(CachingExampleCacheStore5).to_not receive(:read)
       expect_any_instance_of(Flexirest::Connection).to receive(:put).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body: {result: "foo"}.to_json, response_headers:{})))
       ret = Person.save_all
     end
 
     it 'queries the server when the cache has expired' do
-      cached_response = Flexirest::CachedResponse.new(
-        status: 200,
-        result: @cached_object,
-        etag: @etag
-      )
+      headers = {
+        Rack::ETAG => @etag
+      }
+      cached_response = Rack::Cache::Response.new(200, headers, @cached_object.to_json)
       allow_any_instance_of(CachingExampleCacheStore5).to receive(:read).and_return(Marshal.dump(cached_response))
       new_name = 'Pete'
       response_body = Person.new(first_name: new_name).to_json
@@ -173,22 +174,65 @@ describe Flexirest::Caching do
       expect(result.first_name).to eq new_name
     end
 
+    it "should read from the cache store, and not call the server if there's a valid cache-control" do
+       headers = {
+         Rack::CACHE_CONTROL => @cache_control
+       }
+       cached_response = Rack::Cache::Response.new(200, headers, @cached_object.to_json)
+       expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
+       expect_any_instance_of(Flexirest::Connection).not_to receive(:get)
+       ret = Person.all
+       expect(ret.first_name).to eq("Johnny")
+    end
+
+    it "should read from the cache store and restore to the same object in the case of cache-control" do
+      headers = {
+          Rack::CACHE_CONTROL => @cache_control
+      }
+      cached_response = Rack::Cache::Response.new(200, headers, @cached_object.to_json)
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
+      expect_any_instance_of(Flexirest::Connection).not_to receive(:get)
+      p = Person.new(first_name:"Billy")
+      ret = p.all({})
+      expect(ret.first_name).to eq("Johnny")
+    end
+
+    it "should restore a result iterator from the cache store, if there's a cache-control" do
+      class CachingExample3 < Flexirest::Base ; end
+      object = Flexirest::ResultIterator.new(double(status: 200))
+      object << CachingExample3.new(first_name:"Johnny")
+      object << CachingExample3.new(first_name:"Billy")
+      etag = "6527914a91e0c5769f6de281f25bd891"
+      cache_control = "public; max-age=30"
+      headers = {
+          Rack::CACHE_CONTROL => cache_control,
+          Rack::ETAG => etag,
+          Rack::EXPIRES => (Time.now + 30).httpdate
+      }
+      cached_response = Rack::Cache::Response.new(200, headers, object.items.as_json)
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
+      expect_any_instance_of(Flexirest::Connection).not_to receive(:get)
+      ret = Person.all
+      expect(ret.first.first_name).to eq("Johnny")
+      expect(ret._status).to eq(200)
+    end
+
     it "should read from the cache store, and not call the server if there's a hard expiry" do
-      cached_response = Flexirest::CachedResponse.new(
-        status:200,
-        result:@cached_object,
-        expires:Time.now + 30)
+      headers = {
+        Rack::EXPIRES => (Time.now + 30).httpdate
+      }
+      cached_response = Rack::Cache::Response.new(200, headers, @cached_object.to_json)
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
       expect_any_instance_of(Flexirest::Connection).not_to receive(:get)
       ret = Person.all
       expect(ret.first_name).to eq("Johnny")
     end
 
-    it "should read from the cache store and restore to the same object" do
-      cached_response = Flexirest::CachedResponse.new(
-        status:200,
-        result:@cached_object,
-        expires:Time.now + 30)
+    it "should read from the cache store and restore to the same object in the case of expires" do
+      headers = {
+          Rack::EXPIRES => (Time.now + 30).httpdate
+      }
+      cached_response = Rack::Cache::Response.new(200, headers, @cached_object.to_json)
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
       expect_any_instance_of(Flexirest::Connection).not_to receive(:get)
       p = Person.new(first_name:"Billy")
@@ -202,11 +246,11 @@ describe Flexirest::Caching do
       object << CachingExample3.new(first_name:"Johnny")
       object << CachingExample3.new(first_name:"Billy")
       etag = "6527914a91e0c5769f6de281f25bd891"
-      cached_response = Flexirest::CachedResponse.new(
-        status:200,
-        result:object,
-        etag:etag,
-        expires:Time.now + 30)
+      headers = {
+          Rack::ETAG => etag,
+          Rack::EXPIRES => (Time.now + 30).httpdate
+      }
+      cached_response = Rack::Cache::Response.new(200, headers, object.items.as_json)
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(Marshal.dump(cached_response))
       expect_any_instance_of(Flexirest::Connection).not_to receive(:get)
       ret = Person.all
@@ -224,7 +268,7 @@ describe Flexirest::Caching do
     it "should write the response to the cache if there's an etag" do
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(nil)
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:write).once.with("Person:/", an_instance_of(String), {})
-      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{etag:"1234567890"})))
+      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{Rack::ETAG=>"1234567890"})))
       Person.perform_caching true
       Person.all
     end
@@ -232,7 +276,7 @@ describe Flexirest::Caching do
     it "should not write the response to the cache if there's an etag but perform_caching is off" do
       expect(Person.cache_store).to_not receive(:read)
       expect(Person.cache_store).to_not receive(:write)
-      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{etag:"1234567890"})))
+      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{Rack::ETAG=>"1234567890"})))
       Person.perform_caching false
       Person.all
     end
@@ -245,17 +289,33 @@ describe Flexirest::Caching do
         Person.cache_store = CachingExampleCacheStore5.new
         expect(Person.cache_store).to_not receive(:read)
         expect(Person.cache_store).to_not receive(:write)
-        expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{etag:"1234567890"})))
+        expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{Rack::ETAG=>"1234567890"})))
         Person.all
       ensure
         Flexirest::Base.perform_caching caching
       end
     end
 
+    it "should write the response to the cache if there's a valid cache-control" do
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(nil)
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:write).once.with("Person:/", an_instance_of(String), an_instance_of(Hash))
+      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{Rack::CACHE_CONTROL=>"public, max-age=30"})))
+      Person.perform_caching = true
+      Person.all
+    end
+
+    it "should not write the response to the cache if there's an invalid cache-control" do
+      expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(nil)
+      expect_any_instance_of(CachingExampleCacheStore5).to_not receive(:write).once.with("Person:/", an_instance_of(String), an_instance_of(Hash))
+      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{Rack::CACHE_CONTROL=>"public, max-age=0"}))
+      Person.perform_caching = true
+      Person.all
+    end
+
     it "should write the response to the cache if there's a hard expiry" do
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(nil)
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:write).once.with("Person:/", an_instance_of(String), an_instance_of(Hash))
-      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{expires:(Time.now + 30).rfc822})))
+      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, body:"{\"result\":true}", response_headers:{Rack::EXPIRES=>(Time.now + 30).httpdate})))
       Person.perform_caching = true
       Person.all
     end
@@ -263,7 +323,7 @@ describe Flexirest::Caching do
     it "should not write the response to the cache if there's an invalid expiry" do
       expect_any_instance_of(CachingExampleCacheStore5).to receive(:read).once.with("Person:/").and_return(nil)
       expect_any_instance_of(CachingExampleCacheStore5).to_not receive(:write).once.with("Person:/", an_instance_of(String), an_instance_of(Hash))
-      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{expires:"0"}))
+      expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/", an_instance_of(Hash)).and_return(OpenStruct.new(status:200, body:"{\"result\":true}", headers:{Rack::EXPIRES=>"0"}))
       Person.perform_caching = true
       Person.all
     end

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -169,6 +169,7 @@ describe Flexirest::Base do
 
     headers = {
       Rack::CACHE_CONTROL => @cache_control,
+      'Date' => Time.now.httpdate,
       Rack::ETAG => @etag,
       Rack::EXPIRES => (Time.now + 30).httpdate
     }


### PR DESCRIPTION
Hi,

To my understanding, there is a lack somewhere for the HTTP Caching because Cache-Control is missing and when using Rails, the **expires_in** and **expires_now** methods use this Cache-Control header to make use of the HTTP 1.1 Caching feature (it doesn't rely on Expires header).

From the [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html) : 

> Servers specify explicit expiration times using either the Expires header, or the max-age directive of the Cache-Control header.

Even though I haven't a complete understanding of the whole Caching feature of HTTP 1.1, I wanted to add the possibility to use the Cache-Control inside of Flexirest. For this, I have added a dependency to the Rack-Cache gem because it follows quite well the specification, even if I didn't use all of the features of the gem.

I tried my best to respect the contribution guide lines and to include some tests, although I may have missed some.