### PR TITLE
Bugfix #132: JSON-API calls do not include linked resources when no other parameter is passed

### DIFF
--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -12,17 +12,26 @@ This proxy translates requests according to the JSON API specifications, parses 
 
 It supports lazy loading by default. Unless a compound document is returned from the connected JSON API service, it will make another request to the service for the specified linked resource.
 
+
+## Including associations
+
 To reduce the number of requests to the service, you can ask the service to include the linked resources in the response. Such responses are called "compound documents". To do this, use the `includes` method:
 
 ```ruby
-# Makes a call to /articles with parameters: include=images
+# Makes a call to: /articles?include=images
 Article.includes(:images).all
 
-# For nested resources, the include parameter becomes: include=images.tags,images.photographer
+# Fetch nested resources: /articles?include=images.tags,images.photographer
 Article.includes(:images => [:tags, :photographer]).all
+
+# Note: the `includes` method takes precedence over the passed `:include` parameter.
+# This will result in query: /articles?include=images
+Article.includes(:images).all(include: "author")
 ```
 
-For POST and PATCH requests, the proxy formats a JSON API compliant request, and adds a `Content-Type: application/vnd.api+json` header. It guesses the `type` value in the resource object from the class name, but it can be set specifically with `alias_type`:
+## Resource type
+
+The `type` value is guessed from the class name, but it can be set specifically with `alias_type`:
 
 ```ruby
 class Photographer < Flexirest::Base
@@ -34,7 +43,10 @@ class Photographer < Flexirest::Base
 end
 ```
 
-NB: Updating relationships is not yet supported.
+
+## Notes
+
+Updating relationships is not yet supported.
 
 
 -----

--- a/lib/flexirest/json_api_proxy.rb
+++ b/lib/flexirest/json_api_proxy.rb
@@ -50,11 +50,8 @@ module Flexirest
         end
 
         def translate(params, include_associations)
-          # Return to caller if nothing is to be done
-          return params unless params.present? && include_associations.present?
-
           # Format the linked resources array, and assign to include key
-          params[:include] = format_include_params(include_associations)
+          params[:include] = format_include_params(include_associations) if include_associations.present?
         end
 
         private

--- a/spec/lib/json_api_spec.rb
+++ b/spec/lib/json_api_spec.rb
@@ -303,7 +303,7 @@ describe 'JSON API' do
   let(:tags) { JsonAPIExample::Tag }
   let(:author) { JsonAPIExample::Author }
 
-  context 'responses' do
+  describe 'responses' do
     it 'should return the data object if the response contains only one data instance' do
       expect(subject.find(1)).to be_an_instance_of(JsonAPIExampleArticle)
     end
@@ -370,17 +370,17 @@ describe 'JSON API' do
     end
   end
 
-  context 'attributes' do
+  describe 'attributes' do
     it 'should return the attributes as part of the data instance' do
-      expect(subject.find(1).item).to_not be_nil
+      expect(subject.find(1).item).to eq("item one")
     end
 
     it 'should return the association\'s attributes as part of the association instance' do
-      expect(subject.includes(:author).find_single_author(1).author.item).to_not be_nil
+      expect(subject.includes(:author).find_single_author(1).author.item).to eq("item two")
     end
   end
 
-  context 'associations' do
+  describe 'associations' do
     it 'should retrieve the resource\'s associations via its relationships object' do
       expect(subject.includes(:tags).find(1).tags.size).to eq(2)
     end
@@ -415,6 +415,40 @@ describe 'JSON API' do
     end
   end
 
+  describe 'requests' do
+    describe 'the `include=` parameter' do
+      before { stub_request(:get, %r{example\.com/articles}) }
+
+      context 'when using `.includes(:tags)`' do
+        it 'equal "tags"' do
+          JsonAPIExample::Article.includes(:tags).real_index
+          expect(WebMock).to have_requested(:get, 'http://www.example.com/articles?include=tags')
+        end
+      end
+
+      context 'when using `.includes(tags: [:authors, :articles])`' do
+        it 'equal "tags.authors,tags.articles"' do
+          JsonAPIExample::Article.includes(tags: [:authors, :articles]).real_index
+          expect(WebMock).to have_requested(:get, 'http://www.example.com/articles?include=tags.authors,tags.articles')
+        end
+      end
+
+      context 'when using both `.includes(:tags)` and other params in the final call' do
+        it 'uses the values passed to the `includes() method`' do
+          JsonAPIExample::Article.includes(:tags).real_index(filter: { author_id: 4 })
+          expect(WebMock).to have_requested(:get, 'http://www.example.com/articles?filter%5Bauthor_id%5D=4&include=tags')
+        end
+      end
+
+      context 'when using both `.includes(:tags)` and the :include param in final call' do
+        it 'uses the values passed to the `includes() method`' do
+          JsonAPIExample::Article.includes(:tags).real_index(include: "author")
+          expect(WebMock).to have_requested(:get, 'http://www.example.com/articles?include=tags')
+        end
+      end
+    end
+  end
+
   context 'lazy loading' do
     it 'should fetch association lazily' do
       stub_request(:get, /www.example.com\/articles\/1\/tags/)
@@ -434,7 +468,7 @@ describe 'JSON API' do
     end
   end
 
-  context 'client' do
+  describe 'client' do
     it 'should request with json api format, and expect a json api response' do
       expect_any_instance_of(Flexirest::Connection).to receive(:post) { |_, _, _, options|
         expect(options[:headers]).to include('Content-Type' => 'application/vnd.api+json')


### PR DESCRIPTION
I dedcided to clarify the behaviour when both using the `includes` method and passing a `:include` param.

This was an opportunity to add tests about how the query string is built in relation to the `includes` method, so that's what I did! =)

Fixes #132