### PR TITLE
Implement support for in-header Basic Auth

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -64,8 +64,6 @@ end
 #   Authorization: Basic YXBpOmViNjkzZWMtODI1MmMtZDYzMDEtMDJmZDAtZDBmYjctYzM0ODU=
 ```
 
-You need to configure your model as such:
-
 ## Api-Auth
 
 Using the [Api-Auth](https://github.com/mgomes/api_auth) integration it is very easy to sign requests. Include the Api-Auth gem in your `Gemfile` and  then add it to your application. Then simply configure Api-Auth one time in your app and all requests will be signed from then on.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -40,6 +40,32 @@ Or if it's called from a class context:
 Person.find(id: 1234)
 ```
 
+### Basic authentication method
+
+Flexirest provides two methods for HTTP Basic Auth. The default method is `:url`:
+
+```ruby
+class Person < Flexirest::Base
+  basic_auth_method :url
+end
+# Includes the credentials in the URL:
+#   https://my_username:my_password@example.com/
+```
+
+But you might want to keep the credentials out of your logs and use the `:header` method:
+
+```ruby
+class Person < Flexirest::Base
+  basic_auth_method :header
+end
+# Clean URL:
+#   https://example.com/
+# with the base64 encoded credentials:
+#   Authorization: Basic YXBpOmViNjkzZWMtODI1MmMtZDYzMDEtMDJmZDAtZDBmYjctYzM0ODU=
+```
+
+You need to configure your model as such:
+
 ## Api-Auth
 
 Using the [Api-Auth](https://github.com/mgomes/api_auth) integration it is very easy to sign requests. Include the Api-Auth gem in your `Gemfile` and  then add it to your application. Then simply configure Api-Auth one time in your app and all requests will be signed from then on.

--- a/lib/flexirest/configuration.rb
+++ b/lib/flexirest/configuration.rb
@@ -136,16 +136,19 @@ module Flexirest
       end
 
       DEFAULT_BASIC_URL_METHOD = :url
-      VALID_BASIC_URL_METHODS = [:url, :header]
 
-      def basic_auth_method(method = nil)
-        if method.nil? # Used as a getter method
-          @basic_auth_method || DEFAULT_BASIC_URL_METHOD
-        else # Used as a setter method
-          unless [:header, :url].include?(method)
-            raise %(Invalid basic_auth_method #{method.inspect}. Valid methods are #{VALID_BASIC_URL_METHODS.inspect}.)
+      def basic_auth_method(value = nil)
+        if value.nil? # Used as a getter method
+          if @basic_auth_method.nil? && superclass.respond_to?(:basic_auth_method)
+            superclass.basic_auth_method
+          else
+            @basic_auth_method || DEFAULT_BASIC_URL_METHOD
           end
-          @basic_auth_method = method
+        else # Used as a setter method
+          unless [:header, :url].include?(value)
+            raise %(Invalid basic_auth_method #{value.inspect}. Valid methods are :url (default) and :header.)
+          end
+          @basic_auth_method = value
         end
       end
 
@@ -325,7 +328,7 @@ module Flexirest
         @adapter              = Faraday.default_adapter
         @api_auth_access_id   = nil
         @api_auth_secret_key  = nil
-        @basic_auth_method    = nil
+        @basic_auth_method    = :url
       end
 
       private

--- a/lib/flexirest/configuration.rb
+++ b/lib/flexirest/configuration.rb
@@ -135,6 +135,25 @@ module Flexirest
         @@password = value
       end
 
+      DEFAULT_BASIC_URL_METHOD = :url
+      VALID_BASIC_URL_METHODS = [:url, :header]
+
+      def basic_auth_method(*params)
+        case params.size
+        when 0 # Used as a getter method
+          @basic_auth_method || DEFAULT_BASIC_URL_METHOD
+        when 1 # Used as a setter method
+          method_type = params.first
+          unless [:header, :url].include?(method_type)
+            raise %(Invalid basic_auth_method #{method_type.inspect}. Valid methods are #{VALID_BASIC_URL_METHODS.inspect}.)
+          end
+
+          @basic_auth_method = method_type
+        else
+          raise "basic_auth_method can only take one parameter"
+        end
+      end
+
       def alias_type(value = nil)
         @alias_type ||= nil
         if value.nil?
@@ -311,6 +330,7 @@ module Flexirest
         @adapter              = Faraday.default_adapter
         @api_auth_access_id   = nil
         @api_auth_secret_key  = nil
+        @basic_auth_method    = nil
       end
 
       private

--- a/lib/flexirest/configuration.rb
+++ b/lib/flexirest/configuration.rb
@@ -138,19 +138,14 @@ module Flexirest
       DEFAULT_BASIC_URL_METHOD = :url
       VALID_BASIC_URL_METHODS = [:url, :header]
 
-      def basic_auth_method(*params)
-        case params.size
-        when 0 # Used as a getter method
+      def basic_auth_method(method = nil)
+        if method.nil? # Used as a getter method
           @basic_auth_method || DEFAULT_BASIC_URL_METHOD
-        when 1 # Used as a setter method
-          method_type = params.first
-          unless [:header, :url].include?(method_type)
-            raise %(Invalid basic_auth_method #{method_type.inspect}. Valid methods are #{VALID_BASIC_URL_METHODS.inspect}.)
+        else # Used as a setter method
+          unless [:header, :url].include?(method)
+            raise %(Invalid basic_auth_method #{method.inspect}. Valid methods are #{VALID_BASIC_URL_METHODS.inspect}.)
           end
-
-          @basic_auth_method = method_type
-        else
-          raise "basic_auth_method can only take one parameter"
+          @basic_auth_method = method
         end
       end
 

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -543,7 +543,7 @@ module Flexirest
           else
             _, @base_url, @url = parts
           end
-          if using_basic_auth? && model_class.basic_auth_method = :url
+          if using_basic_auth? && model_class.basic_auth_method == :url
             inject_basic_auth_in_url(base_url)
           end
           connection = Flexirest::ConnectionManager.get_connection(base_url)

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -543,7 +543,7 @@ module Flexirest
           else
             _, @base_url, @url = parts
           end
-          if using_basic_auth? && model_class.basic_auth_method != :header
+          if using_basic_auth? && model_class.basic_auth_method = :url
             inject_basic_auth_in_url(base_url)
           end
           connection = Flexirest::ConnectionManager.get_connection(base_url)
@@ -558,7 +558,7 @@ module Flexirest
         else
           base_url = parts[0]
         end
-        if using_basic_auth? && model_class.basic_auth_method != :header
+        if using_basic_auth? && model_class.basic_auth_method == :url
           inject_basic_auth_in_url(base_url)
         end
         connection = Flexirest::ConnectionManager.get_connection(base_url)

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -361,7 +361,7 @@ describe Flexirest::Request do
     end.to raise_error(RuntimeError, "Invalid basic_auth_method :some_invalid_value. Valid methods are :url (default) and :header.")
   end
 
-  it "should use the setting set on the aprent class" do
+  it "should use the setting set on the parent class" do
     mocked_response = ::FaradayResponseMock.new(OpenStruct.new(body:'{"result":true}', response_headers:{}))
     headers_including_auth = hash_including({ "Authorization" => "Basic am9objpzbWl0aA==" })
 


### PR DESCRIPTION
Fixes #138

Let me know if there is something you would change in the docs or code.

Note: I added the `model_class` method to `request.rb`, I think it might be very useful to simplify these kinds of things:

```ruby
      if object_is_class?
        @object.using_api_auth?
      else
        @object.class.using_api_auth?
      end
```

But that is for another PR. :wink: 