### PR TITLE
Add missing require for active_model_form_support

### DIFF
--- a/lib/flexirest.rb
+++ b/lib/flexirest.rb
@@ -1,6 +1,7 @@
 require 'active_support/all'
 require "flexirest/version"
 require "flexirest/attribute_parsing"
+require "flexirest/active_model_form_support"
 require "flexirest/associations"
 require "flexirest/mapping"
 require "flexirest/caching"


### PR DESCRIPTION
Right now you have to manually require `active_model_form_support` to include it in your Flexirest model. Not sure if the missing require here was an oversight, or to reduce the code that is loaded if you don't need it.

```ruby
require "flexirest/active_model_form_support"

class User < Flexirest::Base
  include Flexirest::ActiveModelFormSupport
end
```

Also do you think this should be in the docs somewhere? Could add a new section to README.md that links to a new markdown guide for it.