### PR TITLE
Handle case when specified ignore_root element is not in response

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -862,14 +862,14 @@ module Flexirest
 
         if ignore_root
           [ignore_root].flatten.each do |key|
-            body = body[key.to_s]
+            body = body[key.to_s] if body.has_key?(key.to_s)
           end
         end
       elsif is_xml_response?
         body = @response.body.blank? ? {} : Crack::XML.parse(@response.body)
         if ignore_root
           [ignore_root].flatten.each do |key|
-            body = body[key.to_s]
+            body = body[key.to_s] if body.has_key?(key.to_s)
           end
         elsif options[:ignore_xml_root]
           Flexirest::Logger.warn("Using `ignore_xml_root` is deprecated, please switch to `ignore_root`")

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -206,6 +206,16 @@ describe Flexirest::Request do
       }
     end
 
+    class IgnoredRootWithUnexpectedResponseExampleClient < ExampleClient
+      get :root, "/root", ignore_root: "feed", fake: %Q{
+        {
+          "error": {
+            "message": "Example Error"
+          }
+        }
+      }
+    end
+
     class IgnoredMultiLevelRootExampleClient < ExampleClient
       get :multi_level_root, "/multi-level-root", ignore_root: [:response, "data", "object"], fake: %Q{
         {
@@ -1522,6 +1532,10 @@ describe Flexirest::Request do
 
   it "should ignore a specified root element" do
     expect(IgnoredRootExampleClient.root.title).to eq("Example Feed")
+  end
+
+  it "should ignore an ignore_root parameter if the specified element is not in the response" do
+    expect(IgnoredRootWithUnexpectedResponseExampleClient.root.error.message).to eq("Example Error")
   end
 
   it "should ignore a specified multi-level root element" do


### PR DESCRIPTION
This is to avoid the error:

Failure/Error: attributes["_links"] = attributes[:_links] if attributes[:_links]

     NoMethodError:
       undefined method `[]' for nil:NilClass
     # ./lib/flexirest/request.rb:792:in `handle_hal_links_embedded'
     # ./lib/flexirest/request.rb:717:in `new_object'
     # ./lib/flexirest/request.rb:890:in `generate_new_object'
     # ./lib/flexirest/request.rb:650:in `handle_response'