### PR TITLE
Set Flexirest::Base.base_url to empty string to prevent order dependent test failures

### DIFF
--- a/spec/lib/base_without_validation_spec.rb
+++ b/spec/lib/base_without_validation_spec.rb
@@ -236,6 +236,8 @@ describe Flexirest::BaseWithoutValidation do
 
     Flexirest::Base.base_url = "https://www.example.com/api/v2"
     expect(OutsideBaseExample.base_url).to eq("https://www.example.com/api/v2")
+  ensure
+    Flexirest::Base.base_url = ''
   end
 
   it "should include the Mapping module" do


### PR DESCRIPTION
Example of failing tests https://github.com/flexirest/flexirest/runs/3420330014?check_suite_focus=true