### PR TITLE
Using Faraday ~> 2.7 on Ruby > 2.7.0

### DIFF
--- a/flexirest.gemspec
+++ b/flexirest.gemspec
@@ -36,20 +36,31 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-rcov"
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency "api-auth", ">= 1.3.1", "< 2.4"
-  spec.add_development_dependency 'typhoeus'
+  ruby_below_2_7_0 = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
+  if ruby_below_2_7_0
+    spec.add_development_dependency "api-auth", ">= 1.3.1", "< 2.4"
+    spec.add_development_dependency 'typhoeus'
+  else
+    spec.add_development_dependency "api-auth", ">= 2.4"
+    spec.add_development_dependency 'faraday-typhoeus'
+  end
   spec.add_development_dependency 'activemodel'
   spec.add_development_dependency 'rest-client'
 
   spec.add_runtime_dependency "mime-types"
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "crack"
-  spec.add_runtime_dependency "faraday", "~> 1.0"
+  if ruby_below_2_7_0
+    spec.add_runtime_dependency "faraday", "~> 1.0"
+  else
+    spec.add_runtime_dependency "faraday", "~> 2.7"
+  end
 
   # Use Gem::Version to parse the Ruby version for reliable comparison
   # ActiveSupport 5+ requires Ruby 2.2.2
   if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('2.2.2')
     spec.add_runtime_dependency "activesupport"
+    spec.add_runtime_dependency "actionpack" unless ruby_below_2_7_0
   else
     spec.add_runtime_dependency "activesupport", "< 5.0.0"
   end

--- a/lib/flexirest/base_without_validation.rb
+++ b/lib/flexirest/base_without_validation.rb
@@ -220,7 +220,7 @@ module Flexirest
       if value.is_a?(String) && value.length > 50
         "#{value[0..50]}...".inspect
       elsif value.is_a?(Date) || value.is_a?(Time)
-        %("#{value.to_s(:db)}")
+        %("#{value.respond_to?(:to_fs) ? value.to_fs(:db) : value.to_s(:db)}")
       else
         value.inspect
       end

--- a/lib/flexirest/connection_manager.rb
+++ b/lib/flexirest/connection_manager.rb
@@ -20,7 +20,7 @@ module Flexirest
     def self.in_parallel(base_url)
       begin
         require 'typhoeus'
-        require 'typhoeus/adapters/faraday'
+        require 'typhoeus/adapters/faraday' unless Gem.loaded_specs["faraday-typhoeus"].present?
       rescue LoadError
         raise MissingOptionalLibraryError.new("To call '::Flexirest::ConnectionManager.in_parallel' you must include the gem 'Typhoeus' in your Gemfile.")
       end

--- a/spec/lib/connection_manager_spec.rb
+++ b/spec/lib/connection_manager_spec.rb
@@ -35,13 +35,15 @@ describe Flexirest::ConnectionManager do
   end
 
   it "should call 'in_parallel' for a session and yield procedure inside that block" do
+    require 'faraday/typhoeus' if Gem.loaded_specs["faraday-typhoeus"].present?
     Flexirest::Base.adapter = :typhoeus
     Flexirest::ConnectionManager.get_connection("http://www.example.com").session
     expect { |b| Flexirest::ConnectionManager.in_parallel("http://www.example.com", &b)}.to yield_control
     Flexirest::Base._reset_configuration!
   end
 
-  it "should raise Flexirest::MissingOptionalLibraryError if Typhous isn't available" do
+  it "should raise Flexirest::MissingOptionalLibraryError if Typhoeus isn't available" do
+    require 'faraday/typhoeus' if Gem.loaded_specs["faraday-typhoeus"].present?
     Flexirest::Base.adapter = :typhoeus
     Flexirest::ConnectionManager.get_connection("http://www.example.com").session
     expect(Flexirest::ConnectionManager).to receive(:require).and_raise(LoadError)

--- a/spec/lib/connection_spec.rb
+++ b/spec/lib/connection_spec.rb
@@ -175,13 +175,24 @@ describe Flexirest::Connection do
       expect(auth_header == "APIAuth id123:TQiQIW6vVaDC5jvh99uTNkxIg6Q=" || auth_header == "APIAuth id123:PMWBThkB8vKbvUccHvoqu9G3eVk=").to be_truthy
     end
 
-    it 'should have an Content-MD5 header' do
-      stub_request(:put, "www.example.com/foo").
-        with(body: "body", :headers => @default_headers).
-        to_return(body: "{result:true}")
+    if Gem.loaded_specs["api-auth"].present? && Gem.loaded_specs["api-auth"].version.to_s < "2.5.0"
+      it 'should have an Content-MD5 header' do
+        stub_request(:put, "www.example.com/foo").
+          with(body: "body", :headers => @default_headers).
+          to_return(body: "{result:true}")
 
-      result = @connection.put("/foo", "body", @options)
-      expect(result.env.request_headers['Content-MD5']).to eq("hBotaJrYa9FhFEdFPCLG/A==")
+        result = @connection.put("/foo", "body", @options)
+        expect(result.env.request_headers['Content-MD5']).to eq("hBotaJrYa9FhFEdFPCLG/A==")
+      end
+    else
+      it 'should have an X-AUTHORIZATION-CONTENT-SHA256 header' do
+        stub_request(:put, "www.example.com/foo").
+          with(body: "body", :headers => @default_headers).
+          to_return(body: "{result:true}")
+
+        result = @connection.put("/foo", "body", @options)
+        expect(result.env.request_headers['X-AUTHORIZATION-CONTENT-SHA256']).to eq("Iw2DWNyOiJC0xY3utikS7i8gNXrpKlzIYbmOaP4xrLU=")
+      end
     end
   end
 

--- a/spec/lib/instrumentation_spec.rb
+++ b/spec/lib/instrumentation_spec.rb
@@ -10,6 +10,9 @@ describe Flexirest::Instrumentation do
   it "should save a load hook to include the instrumentation" do
     hook_tester = double("HookTester")
     expect(hook_tester).to receive(:include).with(Flexirest::ControllerInstrumentation)
+    if Gem.loaded_specs["api-auth"].present? && Gem.loaded_specs["api-auth"].version.to_s >= "2.5.0"
+      require "action_controller"
+    end
     ActiveSupport.run_load_hooks(:action_controller, hook_tester)
   end
 


### PR DESCRIPTION
I had the wish to use Faraday version 2 since a while now, and I have created this Pull Request.

I made the assumption that above Ruby version 2.7.0 we could use the last minor Faraday version (~> 2.7).
Don't hesitate to bring your own ideas or suggestions, and to correct anything that seems wrong.

All the tests are passing after some adaptions but I didn't have the chance to test it on a real use-case.

Hope this could be a good starting point.