### PR TITLE
Cache entry should be deleted when expires header is passed

### DIFF
--- a/flexirest.gemspec
+++ b/flexirest.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'faraday-typhoeus'
   spec.add_development_dependency 'activemodel'
   spec.add_development_dependency 'rest-client'
+  spec.add_development_dependency 'timecop'
 
   spec.add_runtime_dependency "mime-types"
   spec.add_runtime_dependency "multi_json"

--- a/lib/flexirest/caching.rb
+++ b/lib/flexirest/caching.rb
@@ -74,7 +74,14 @@ module Flexirest
           cached_response.etag = "#{headers[:etag]}" if headers[:etag]
           cached_response.expires = Time.parse(headers[:expires]) rescue nil if headers[:expires]
           if cached_response.etag.present? || cached_response.expires
-            cache_store.write(key, Marshal.dump(cached_response), {})
+            options = {}
+            if cached_response.expires.present?
+              exp_in_seconds = cached_response.expires.utc - Time.now.utc
+              return unless exp_in_seconds.positive?
+
+              options[:expires_in] = exp_in_seconds
+            end
+            cache_store.write(key, Marshal.dump(cached_response), options)
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'simplecov'
 require 'flexirest'
 require "ostruct"
 require 'webmock/rspec'
+require 'timecop'
 
 if ENV["JENKINS"]
   require 'simplecov-rcov'


### PR DESCRIPTION
I thought it might be good to delete the cache entry if expires header has been set and was already passed.