### PR TITLE
Forward all Flexirest::ResultIterator#index args

### DIFF
--- a/lib/flexirest/result_iterator.rb
+++ b/lib/flexirest/result_iterator.rb
@@ -33,8 +33,8 @@ module Flexirest
       @items.join(*args)
     end
 
-    def index(value)
-      @items.index(value)
+    def index(...)
+      @items.index(...)
     end
 
     def empty?

--- a/spec/lib/result_iterator_spec.rb
+++ b/spec/lib/result_iterator_spec.rb
@@ -74,6 +74,7 @@ describe Flexirest::ResultIterator do
     result << "a"
     result << "z"
     expect(result.index("z")).to eq(1)
+    expect(result.index { |i| i == "z" }).to eq(1)
   end
 
   it "should implement empty?" do


### PR DESCRIPTION
All the arguments, not just positional arguments, received by a call to
`Flexirest::ResultIterator#index` are forwarded to the `index` method
of the iterator's `items` instance variable.

This enables `Flexirest::ResultIterator#index` to, optionally, take a block as an
argument and pass it along.

Currently, attempting to use a block with `Flexirest::ResultIterator#index` will raise an error

```ruby
result = Flexirest::ResultIterator.new
result << "a
result << "z"
result.index { |i| i == "z" } # raises an error: wrong number of arguments (given 0, expected 1) (ArgumentError)
```

Not a big deal since we can just do

```ruby
result.items.index { |i| i == "z" }
```

and it should work just fine but it would be nice to have for the sake of completeness in my opinion. 😄 