### PR TITLE
Do not raise undefined method error when ignore_root value is null

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -874,14 +874,14 @@ module Flexirest
 
         if ignore_root
           [ignore_root].flatten.each do |key|
-            body = body[key.to_s] if body.has_key?(key.to_s)
+            body = body[key.to_s] || {} if body.has_key?(key.to_s)
           end
         end
       elsif is_xml_response?
         body = @response.body.blank? ? {} : Crack::XML.parse(@response.body)
         if ignore_root
           [ignore_root].flatten.each do |key|
-            body = body[key.to_s] if body.has_key?(key.to_s)
+            body = body[key.to_s] || {} if body.has_key?(key.to_s)
           end
         elsif options[:ignore_xml_root]
           Flexirest::Logger.warn("Using `ignore_xml_root` is deprecated, please switch to `ignore_root`")

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -214,6 +214,14 @@ describe Flexirest::Request do
       }
     end
 
+    class IgnoredRootWithNullValueExampleClient < ExampleClient
+      get :root, "/root", ignore_root: "feed", fake: %Q{
+        {
+          "feed": null
+        }
+      }
+    end
+
     class IgnoredRootWithUnexpectedResponseExampleClient < ExampleClient
       get :root, "/root", ignore_root: "feed", fake: %Q{
         {
@@ -1571,6 +1579,10 @@ describe Flexirest::Request do
 
   it "should ignore a specified root element" do
     expect(IgnoredRootExampleClient.root.title).to eq("Example Feed")
+  end
+
+  it "should not raise an error if ignore_root value is null" do
+    expect(IgnoredRootWithNullValueExampleClient.root).to be_instance_of(IgnoredRootWithNullValueExampleClient)
   end
 
   it "should ignore an ignore_root parameter if the specified element is not in the response" do


### PR DESCRIPTION
This is to avoid the error:

```spec
     Failure/Error: attributes["_links"] = attributes[:_links] if attributes[:_links]
     
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # ./lib/flexirest/request.rb:804:in `handle_hal_links_embedded'
     # ./lib/flexirest/request.rb:730:in `new_object'
     # ./lib/flexirest/request.rb:902:in `generate_new_object'
     # ./lib/flexirest/request.rb:662:in `handle_response'
```